### PR TITLE
fix(ci): correct image tagging and PyPI publishing logic

### DIFF
--- a/.github/workflows/release-oci-image.yml
+++ b/.github/workflows/release-oci-image.yml
@@ -32,7 +32,7 @@ jobs:
         outputs:
             generated_version: ${{ steps.output-generated-version.outputs.generated_version }}
             image_tag: ${{ steps.generate_tag.outputs.image_tag }}
-            image_tag_latest: ${{ steps.output-generated-version.outputs.image_tag_latest }}
+            image_tag_latest: ${{ steps.generate_tag.outputs.image_tag_latest }}
             tag_prefix: ${{ steps.generate_tag.outputs.tag_prefix }}
         permissions:
             contents: write
@@ -57,7 +57,6 @@ jobs:
             id: output-generated-version
             run: |
                 echo "generated_version=${{ steps.semantic-version.outputs.version }}" >> $GITHUB_OUTPUT
-                echo "image_tag_latest=${{ env.OCI_REGISTRY }}/${repo_name}:latest" >> $GITHUB_OUTPUT
 
         - 
             name: Version tag ${{ steps.semantic-version.outputs.version }} on main branch or tag
@@ -85,6 +84,7 @@ jobs:
                 # image tag needs to be all lower case
                 repo_name=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]')
                 echo "image_tag=${{ env.OCI_REGISTRY }}/${repo_name}:${{ env.generated_tag }}" >> $GITHUB_OUTPUT
+                echo "image_tag_latest=${{ env.OCI_REGISTRY }}/${repo_name}:latest" >> $GITHUB_OUTPUT
 
     docker-image-release:
         needs: [generate-release-version]

--- a/.github/workflows/release-pypi.yml
+++ b/.github/workflows/release-pypi.yml
@@ -6,6 +6,9 @@ on:
     - v*
     branches:
     - main
+    # paths-ignore:
+    # - .github/**
+    # - ./**/*.md
   pull_request:
     branches:
     - main
@@ -119,8 +122,8 @@ jobs:
 
   publish-to-testpypi:
     name: Publish Python 🐍 distribution 📦 to TestPyPI
-    # we only publish to TestPyPI on tag pushes or merge to main
-    if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
+    # we only publish to TestPyPI on merge to main
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs:
     - build
     runs-on: ubuntu-latest
@@ -142,3 +145,5 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
+        skip-existing: true
+        verbose: true


### PR DESCRIPTION
- Move image_tag_latest output to generate_tag step
- Fix TestPyPI publishing to only trigger on main branch pushes
- Add skip-existing and verbose flags to PyPI publish action
- Clean up workflow trigger conditions