### PR TITLE
feat: #33 add a sample end to end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ src/logs/indexer_skills.log
 
 # chroma index sqlite3
 src/localhost/chroma.sqlite3
+
+# Generated sample vector stores
+samples/**/output/

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ ${OCI_ENGINE}  run -it --rm \
 
 # Documentation
 
+If you are discovering `docs2vecs` for the first time, start with the [samples](samples/) folder. It contains clear end-to-end examples with local data, ready-to-run config files, and step-by-step README instructions so you can understand how the indexer works before adapting it to your own documents.
+
+The current samples include:
+
+- [PDF only](samples/pdf-only/) — index a local PDF file into a generated ChromaDB collection.
+- [Markdown only](samples/markdown-only/) — index a local Markdown file into a generated ChromaDB collection.
+
 <details><summary>Expand me if you would like to find out how to vectorize your data</summary>
 
 ## Indexer sub-command

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,28 @@
+# docs2vecs Samples
+
+This directory contains end-to-end samples that demonstrate how to use the `docs2vecs` indexer with local files.
+
+## Available Samples
+
+| Sample | Purpose |
+|--------|---------|
+| [PDF only](./pdf-only/) | Index a local PDF file into a generated ChromaDB collection |
+| [Markdown only](./markdown-only/) | Index a local Markdown file into a generated ChromaDB collection |
+
+## Prerequisites
+
+- Python 3.11 or higher
+- `uv`
+- A checkout of this repository
+
+## Usage Pattern
+
+Run sample commands from the repository root:
+
+```bash
+uv run docs2vecs indexer --config samples/<sample-name>/config.yml
+```
+
+Each sample writes a local ChromaDB database under its own `output/` directory. Those generated files are not committed to the repository; they are created when you run the sample.
+
+The first run may take longer while the local embedding model is downloaded.

--- a/samples/markdown-only/README.md
+++ b/samples/markdown-only/README.md
@@ -1,0 +1,31 @@
+# Markdown-Only Sample
+
+This sample indexes a local Markdown document with the `docs2vecs indexer` pipeline.
+
+## Files
+
+| Path | Purpose |
+|------|---------|
+| `samples/markdown-only/input/sample-documentation.md` | Sample Markdown input document |
+| `samples/markdown-only/config.yml` | Ready-to-run indexer configuration |
+| `samples/markdown-only/output/` | Generated ChromaDB output directory created when the sample runs |
+
+## Run
+
+From the repository root:
+
+```bash
+uv run docs2vecs indexer --config samples/markdown-only/config.yml
+```
+
+## Expected Result
+
+After the command completes, `samples/markdown-only/output/` should exist and contain a working ChromaDB database for the `markdown-sample-collection` collection.
+
+You can verify the generated output by checking that:
+
+- the command exits successfully,
+- `samples/markdown-only/output/` is created,
+- the ChromaDB files are present in that output directory.
+
+Generated ChromaDB files are intentionally ignored by git.

--- a/samples/markdown-only/config.yml
+++ b/samples/markdown-only/config.yml
@@ -1,0 +1,40 @@
+definitions:
+  - skill: &FileScanner
+      type: file-scanner
+      name: multi-file-scanner
+      params:
+        path: samples/markdown-only/input
+        filter: ["*.md"]
+        recursive: false
+
+  - skill: &FileReader
+      type: file-reader
+      name: multi-file-reader
+
+  - skill: &TextSplitter
+      type: splitter
+      name: recursive-character-splitter
+      params:
+        chunk_size: 1000
+        overlap: 100
+
+  - skill: &FastEmbed
+      type: embedding
+      name: llama-fastembed
+
+  - skill: &ChromaDB
+      type: vector-store
+      name: chromadb
+      params:
+        db_path: samples/markdown-only/output
+        collection_name: markdown-sample-collection
+
+  - skillset: &MarkdownSkillset
+      - *FileScanner
+      - *FileReader
+      - *TextSplitter
+      - *FastEmbed
+      - *ChromaDB
+
+indexer:
+  skillset: *MarkdownSkillset

--- a/samples/markdown-only/input/sample-documentation.md
+++ b/samples/markdown-only/input/sample-documentation.md
@@ -1,0 +1,33 @@
+# Getting Started with Documentation
+
+This sample Markdown document demonstrates how the `docs2vecs` indexer processes local Markdown files.
+
+## Overview
+
+Documentation often contains concepts, procedures, and examples that are useful in retrieval augmented generation workflows. Indexing the content into a vector store makes it searchable by semantic meaning.
+
+## Key Concepts
+
+### Vector Embeddings
+
+Vector embeddings are numerical representations of text. They help compare pieces of text by meaning instead of exact wording.
+
+### Document Chunking
+
+Long documents are split into smaller chunks before embedding. Smaller chunks make retrieval more precise and keep each vector focused on a coherent idea.
+
+### Local Vector Store
+
+This sample stores generated vectors in a local ChromaDB database under the sample output directory.
+
+## Example Workflow
+
+1. Scan the input directory for Markdown files.
+2. Read Markdown content from each file.
+3. Split the text into chunks.
+4. Generate local embeddings.
+5. Store the chunks and embeddings in ChromaDB.
+
+## Conclusion
+
+This sample is intentionally small so new users can inspect the input, configuration, command, and generated output in one place.

--- a/samples/pdf-only/README.md
+++ b/samples/pdf-only/README.md
@@ -1,0 +1,31 @@
+# PDF-Only Sample
+
+This sample indexes a local PDF document with the `docs2vecs indexer` pipeline.
+
+## Files
+
+| Path | Purpose |
+|------|---------|
+| `samples/pdf-only/input/sample-guide.pdf` | Sample PDF input document |
+| `samples/pdf-only/config.yml` | Ready-to-run indexer configuration |
+| `samples/pdf-only/output/` | Generated ChromaDB output directory created when the sample runs |
+
+## Run
+
+From the repository root:
+
+```bash
+uv run docs2vecs indexer --config samples/pdf-only/config.yml
+```
+
+## Expected Result
+
+After the command completes, `samples/pdf-only/output/` should exist and contain a working ChromaDB database for the `pdf-sample-collection` collection.
+
+You can verify the generated output by checking that:
+
+- the command exits successfully,
+- `samples/pdf-only/output/` is created,
+- the ChromaDB files are present in that output directory.
+
+Generated ChromaDB files are intentionally ignored by git.

--- a/samples/pdf-only/config.yml
+++ b/samples/pdf-only/config.yml
@@ -1,0 +1,40 @@
+definitions:
+  - skill: &FileScanner
+      type: file-scanner
+      name: multi-file-scanner
+      params:
+        path: samples/pdf-only/input
+        filter: ["*.pdf"]
+        recursive: false
+
+  - skill: &FileReader
+      type: file-reader
+      name: multi-file-reader
+
+  - skill: &TextSplitter
+      type: splitter
+      name: recursive-character-splitter
+      params:
+        chunk_size: 1000
+        overlap: 100
+
+  - skill: &FastEmbed
+      type: embedding
+      name: llama-fastembed
+
+  - skill: &ChromaDB
+      type: vector-store
+      name: chromadb
+      params:
+        db_path: samples/pdf-only/output
+        collection_name: pdf-sample-collection
+
+  - skillset: &PDFSkillset
+      - *FileScanner
+      - *FileReader
+      - *TextSplitter
+      - *FastEmbed
+      - *ChromaDB
+
+indexer:
+  skillset: *PDFSkillset

--- a/samples/pdf-only/input/sample-guide.pdf
+++ b/samples/pdf-only/input/sample-guide.pdf
@@ -1,0 +1,55 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 594 >>
+stream
+BT
+/F1 18 Tf
+72 720 Td
+(PDF Processing Guide) Tj
+/F1 11 Tf
+0 -36 Td
+(This sample PDF demonstrates local indexing with docs2vecs.) Tj
+0 -18 Td
+(The indexer scans PDF files, reads text, splits content into chunks,) Tj
+0 -18 Td
+(generates local embeddings, and stores vectors in ChromaDB.) Tj
+0 -30 Td
+(Processing steps:) Tj
+0 -18 Td
+(1. Scan the input directory for PDF files.) Tj
+0 -18 Td
+(2. Extract text from the PDF document.) Tj
+0 -18 Td
+(3. Split the text into chunks.) Tj
+0 -18 Td
+(4. Generate embeddings locally.) Tj
+0 -18 Td
+(5. Store the result in the sample ChromaDB collection.) Tj
+ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000311 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+956
+%%EOF

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -94,3 +94,25 @@ def test_config():
     }
     assert actual_vector_store_config is not None
     assert actual_vector_store_config == expected_vector_store_config
+
+
+def test_sample_configs_are_valid():
+    schema_file = Path("src/docs2vecs/subcommands/indexer/config/config_schema.yaml")
+
+    for config_file in (
+        Path("samples/pdf-only/config.yml"),
+        Path("samples/markdown-only/config.yml"),
+    ):
+        config = Config(config_file, schema_file)
+        assert config is not None
+
+        skill_names = [
+            skill_config["name"] for skill_config in config.get_skills_config_dict()
+        ]
+        assert skill_names == [
+            "multi-file-scanner",
+            "multi-file-reader",
+            "recursive-character-splitter",
+            "llama-fastembed",
+            "chromadb",
+        ]


### PR DESCRIPTION
I added a sample folder with two config examples one for pdf and one for markdown to ease user onboarding for docs2vecs